### PR TITLE
added runtime measurement

### DIFF
--- a/examples/int_performance.bli
+++ b/examples/int_performance.bli
@@ -1,0 +1,5 @@
+max := 10000
+i := 0
+while(() => sub(i max)
+    () => i = add(i 1)
+)

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,6 +11,7 @@ use parse::parse;
 
 use std::env;
 use std::fs;
+use std::time::Instant;
 use std::process::exit;
 
 fn main() {
@@ -37,8 +38,11 @@ fn main() {
     exec.initialize_builtins();
     //println!("INITIAL EXECUTOR ->\n    {:?}", exec);
     println!("\n=== OUTPUT ===");
+    let start_time = Instant::now();
     let result = exec.run();
+    let total_time = start_time.elapsed();
     println!("==============\n");
     //println!("FINISHED EXECUTOR ->\n    {:?}", exec);
     println!("RESULT ->\n    {:?}", result);
+    println!("Time Taken: {}μs", total_time.as_micros());
 }


### PR DESCRIPTION
On my machine, running `int_performance.bli`, using `TinyInt` rather than `BigInt` increased performance by 45% (a 31% decrease in total runtime). The overall performance of the interpreter is still somewhat appalling, warranting consideration for a lower level IR among other reworks.